### PR TITLE
Dropdown conflict fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,14 +56,14 @@ gulp.task('get-options', function () {
 
 gulp.task('bootstrap-dropdown', function () {
 	gulp.src('./node_modules/bootstrap/js/dropdown.js')
-		.pipe(wrap('exports.init = function (jQuery) {\n<%= contents %>\nreturn jQuery;\n};'))
+		.pipe(wrap('exports.init = function (jQuery) {\nif (jQuery.fn.dropdown) return jQuery;\n<%= contents %>\nreturn jQuery;\n};'))
 		.pipe(rename('bootstrap-dropdown.js'))
 		.pipe(gulp.dest('./lib'));
 });
 
 gulp.task('bootstrap-multiselect', function () {
 	gulp.src('./lib/bootstrap-multiselect-original.js')
-		.pipe(wrap('exports.init = function (jQuery) {\n<%= contents %>\nreturn jQuery;\n};'))
+		.pipe(wrap('exports.init = function (jQuery) {\nif (jQuery.fn.multiselect) return jQuery;\n<%= contents %>\nreturn jQuery;\n};'))
 		.pipe(replace('window.jQuery', 'jQuery'))
 		.pipe(rename('bootstrap-multiselect.js'))
 		.pipe(gulp.dest('./lib'));

--- a/lib/bootstrap-dropdown.js
+++ b/lib/bootstrap-dropdown.js
@@ -1,4 +1,5 @@
 exports.init = function (jQuery) {
+if (jQuery.fn.dropdown) return jQuery;
 /* ========================================================================
  * Bootstrap: dropdown.js v3.3.5
  * http://getbootstrap.com/javascript/#dropdowns

--- a/lib/bootstrap-multiselect.js
+++ b/lib/bootstrap-multiselect.js
@@ -1,4 +1,5 @@
 exports.init = function (jQuery) {
+if (jQuery.fn.multiselect) return jQuery;
 /**
  * Bootstrap Multiselect (https://github.com/davidstutz/bootstrap-multiselect)
  * 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "BSD-3-Clause"
   ],
   "dependencies": {
-    "jquery": "^2.1.4",
+    "jquery": ">=1.11.3",
     "react": ">=0.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Background story at [PR #11](https://github.com/skratchdot/react-bootstrap-multiselect/pull/11#issuecomment-134479627).

In short, there are two problems here:
1. Bootstrap 3 actually officially supports jQuery 1.11 line, however our plugin here specifies jQuery 2, which causes it to load to the newly loaded jQuery once included.
2. As of Bootstrap 3, it is not really happy if we try to load two different instances on it, even both of them in the same jQuery version.

This PR does two things:
1. Changed `package.json` so that it allows jQuery 1 as well [(diff)](https://github.com/netsgnut/react-bootstrap-multiselect/commit/af09745e5b5601c8e0a78766a57d25d8029aae95)
2. Added guards against double-loading of Bootstrap Dropdown and Multiselect plugin [(diff)](https://github.com/netsgnut/react-bootstrap-multiselect/commit/62c6809dd3a47ed8e926f1c5e90c21aa10e7af67)

This PR should close #11. Not sure if this would solve the problem of the OP for #11, but IMHO that should be closed anyway it probably is not quite the fix (and I wonder if it would be accepted by Bootstrap upstream as well).

Please advise to see if it works for you too. Thanks!