### PR TITLE
Allow 'disabled' property to be toggled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,6 @@ module.exports = React.createClass({
 	$multiselect: null,
 	options: getOptions(),
 	syncData: function(){
-
 		// this function is meant to be called from parent component
 		// in case selected values are changed outside of this component
 		// and need to be synced
@@ -26,7 +25,7 @@ module.exports = React.createClass({
 			this.$multiselect.multiselect('dataprovider', this.props.data || []);
 		}
 	},
-  	setOptionsFromProps: function () {
+	setOptionsFromProps: function () {
 		var currentOptions = {}, needToInit = false, $this = this;
 		if ($this.$multiselect) {
 			$this.options.forEach(function (option) {
@@ -47,12 +46,22 @@ module.exports = React.createClass({
 		$this.$multiselect.multiselect();
 		$this.setOptionsFromProps();
 		$this.$multiselect.multiselect('dataprovider', $this.props.data || []);
+		if ($this.props.disabled) {
+			$this.$multiselect.multiselect('disable');
+		}
 	},
 	componentWillUnmount: function () {
 		if (this.$multiselect) {
 			this.$multiselect.multiselect('destroy');
 		}
 		this.$multiselect = null;
+	},
+	componentWillReceiveProps: function (nextProps) {
+		if (nextProps.disabled) {
+			this.$multiselect.multiselect('disable');
+		} else {
+			this.$multiselect.multiselect('enable');
+		}
 	},
 	render: function () {
 		//this.setOptionsFromProps();


### PR DESCRIPTION
Currently code like the following won't really work:
```js
<Multiselect disabled={ this.state.shouldBeDisabled } />
```

The reason is that the `disabled` property has not been translated accordingly for the `bootstrap-multiselect` plugin to work upon. This PR listens to `prop` change and call the `.multiselect('enable')` and `.multiselect('disable')` accordingly.

Not sure if this is the right pattern to go - I am still getting used to React's pattern. Please feel free to test as well. Thanks.