### PR TITLE
corrected typo enableCollapsibleOptGroups

### DIFF
--- a/lib/get-options.js
+++ b/lib/get-options.js
@@ -15,7 +15,7 @@ module.exports = exports = function () {
 		"dropUp",
 		"enableCaseInsensitiveFiltering",
 		"enableClickableOptGroups",
-		"enableCollapsibelOptGroups",
+		"enableCollapsibleOptGroups",
 		"enableFiltering",
 		"enableFullValueFiltering",
 		"enableHTML",


### PR DESCRIPTION
On file 'get-options.js' there is a typo

>  enableCollapsibelOptGroups

 which should be 

> enableCollapsibleOptGroups

this caused collapsible groups to not work.