### PR TITLE
Fix collapsible group selection

### DIFF
--- a/lib/bootstrap-multiselect.js
+++ b/lib/bootstrap-multiselect.js
@@ -563,6 +563,7 @@ if (jQuery.fn.multiselect) return jQuery;
                 var $checkboxesNotThis = $('input', this.$container).not($target);
 
                 if (isSelectAllOption) {
+
                     if (checked) {
                         this.selectAll(this.options.selectAllJustVisible);
                     }
@@ -571,6 +572,7 @@ if (jQuery.fn.multiselect) return jQuery;
                     }
                 }
                 else {
+
                     if (checked) {
                         $option.prop('selected', true);
 
@@ -726,7 +728,6 @@ if (jQuery.fn.multiselect) return jQuery;
             if(this.options.enableClickableOptGroups && this.options.multiple) {
                 $('li.multiselect-group', this.$ul).on('click', $.proxy(function(event) {
                     event.stopPropagation();
-                    console.log('test');
                     var group = $(event.target).parent();
 
                     // Search all option in optgroup
@@ -755,6 +756,7 @@ if (jQuery.fn.multiselect) return jQuery;
             }
 
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
+
                 $("li.multiselect-group input", this.$ul).off();
                 $("li.multiselect-group", this.$ul).siblings().not("li.multiselect-group, li.multiselect-all", this.$ul).each( function () {
                     $(this).toggleClass('hidden', true);
@@ -765,6 +767,7 @@ if (jQuery.fn.multiselect) return jQuery;
                 }, this));
                 
                 $("li.multiselect-group > a > b", this.$ul).on("click", $.proxy(function(t) {
+
                     t.stopPropagation();
                     var n = $(t.target).closest('li');
                     var r = n.nextUntil("li.multiselect-group");
@@ -823,7 +826,7 @@ if (jQuery.fn.multiselect) return jQuery;
                         i = i && $(this).prop("checked");
                     });
                     
-                    n.prevAll('.multiselect-group').find('input').prop('checked', i);
+                    n.children('.multiselect-group').find('input').prop('checked', i);
                 }, this));
                 
                 $("li.multiselect-all", this.$ul).css('background', '#f3f3f3').css('border-bottom', '1px solid #eaeaea');
@@ -916,7 +919,7 @@ if (jQuery.fn.multiselect) return jQuery;
         createOptgroup: function(group) {            
             if (this.options.enableCollapsibleOptGroups && this.options.multiple) {
                 var label = $(group).attr("label");
-                var value = $(group).attr("value");
+                var value = $(group).attr("label");
                 var r = $('<li class="multiselect-item multiselect-group"><a href="javascript:void(0);"><input type="checkbox" value="' + value + '"/><b> ' + label + '<b class="caret"></b></b></a></li>');
 
                 if (this.options.enableClickableOptGroups) {
@@ -1248,7 +1251,8 @@ if (jQuery.fn.multiselect) return jQuery;
          * @param {Array} deselectValues
          * @param {Boolean} triggerOnChange
          */
-        deselect: function(deselectValues, triggerOnChange) {
+        deselect: function(deselectValues, triggerOnChange) 
+        {
             if(!$.isArray(deselectValues)) {
                 deselectValues = [deselectValues];
             }
@@ -1505,6 +1509,7 @@ if (jQuery.fn.multiselect) return jQuery;
                     this.options.onSelectAll(true);
                 }
                 else {
+
                     selectAllInput.prop("checked", false);
                     selectAllLi.removeClass(this.options.selectedClass);
                     if (checkedBoxesLength === 0) {


### PR DESCRIPTION
Yo,

When using collapsible group. The behaviour when you deselect the last group that you selected seems to be odd, because it deselects all of your previous group selection. Instead of using 

> .prevAll()

I changed it to just 

> .children()