### PR TITLE
React v15.5 createClass deprecation resolution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ if (typeof window !== 'undefined' && window && window.jQuery) {
 
 var BS = require('bootstrap');
 var React = require('react');
+var createReactClass = require('create-react-class');
 var objectAssign = require('object-assign');
 var getOptions = require('./get-options.js');
 var bsMultiselect = require('./bootstrap-multiselect.js');
@@ -27,7 +28,7 @@ $ = bsDropdown.init($);
 $ = bsMultiselect.init($);
 
 /* this is our exported React class */
-module.exports = React.createClass({
+module.exports = createReactClass({
 	displayName: 'MultiSelect',
 	$multiselect: null,
 	options: getOptions(),

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "BSD-3-Clause"
   ],
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "jquery": ">=2.2.0",
     "object-assign": "^4.1.0",
     "react": ">=15.0.0"


### PR DESCRIPTION
Until we know about #68 , this update fixes deprecation warnings for people using this library on React v15.5